### PR TITLE
Update README.md with how user can remove a range of todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,28 @@ Which gives:
     >
 ```
 
+In this example, we will remove a range of todos(from **'Second Todo'** to **'Third Todo'**)
+```
+    0 - [ ] First Todo
+    1 - [X] Second Todo
+    2 - [X] Third Todo
+    3 - [X] Fourth Todo
+    4 - [ ] Fifth Todo
+
+    type an option: (a)dd, (c)heck, (r)emove, (h)elp, (e)xit
+    > r 1-3
+```
+
+Which gives:
+
+```
+    0 - [ ] First Todo
+    1 - [ ] Fifth Todo
+
+    type an option: (a)dd, (c)heck, (r)emove, (h)elp, (e)xit
+    >
+```
+
 ### Documentation
 
 You can open the built-in documentation by typing `h` as such:


### PR DESCRIPTION
#### Before this PR
Under the `Remove Existing Todo` section in the `README`, the explanations there are just for how a user can pick-remove todos. 

#### What does this PR do?
Since the functionality for removing a range of todos has been implemented in https://github.com/Passok11/todo-list-node-cli/pull/24, this Pull Request updates the `README.md` file to include explanations on how a user can remove a range of todos.