### PR TITLE
Show timestamp reflecting latest activity on a todo

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,18 +13,29 @@ const rl = readline.createInterface({
 const template = `[
   {
     "isChecked": false,
-    "text": "Check me to test if is working! "
+    "text": "Check me to test if is working! ",
+    "lastActivity": "created",
+    "lastUpdated": ${Date.now()}
   },
   {
     "isChecked": true,
-    "text": "You can remove this template todo!"
+    "text": "You can remove this template todo!",
+    "lastActivity": "checked",
+    "lastUpdated": ${Date.now()}
   }
 ]`;
+
+function formatTodoTime(time) {
+  const date = new Date(time);
+  return chalk.grey(
+    `${date.getDate()}/${date.getMonth()}/${date.getFullYear()} ${date.getHours()}:${date.getMinutes()}`
+  );
+}
 
 function showTodos() {
   todos.forEach((todo, index)=> {
     const color = todo.isChecked ? success : waiting;
-    console.log(color(`${index} - [${todo.isChecked ? 'X' : ' ' }] ${todo.text}`))
+    console.log(color(`${index} - [${todo.isChecked ? 'X' : ' ' }] ${todo.text}\t ${todo.lastActivity} ${formatTodoTime(todo.lastUpdated)}`))
   });
 }
 
@@ -47,6 +58,8 @@ function addTodo(text) {
     todos.push({
       isChecked: false,
       text,
+      lastActivity: 'created',
+      lastUpdated: Date.now(),
     });
   }
 }
@@ -54,6 +67,8 @@ function checkTodos(ids){
   ids.forEach((id) => {
     if (todos[id]){
       todos[id].isChecked = !todos[id].isChecked;
+      todos[id].lastActivity = 'checked';
+      todos[id].lastUpdated = Date.now();
     }
   });
 }


### PR DESCRIPTION
### Before this PR
A User can see the list of his/her todos. The tods are presented in this format:
```
[todo-identifier] [todo-status] [todo-text]
``` 
### What does this PR do?
With this pull request, a user would be able to see the timestamp that reflects the latest activity on a particular todo, consequently, the todos are presented in this format:
```
[todo-identifier] [todo-status] [todo-text] [latest-activity] [timestamp]
``` 
For now, there are just two basic activities that are reflected by the timestamps which are: `created` and `checked`. This are some example todos with timestamp: 
```
0 - [ ] Check me to test if is working!          created 3/9/2018 14:50
1 - [X] You can remove this template todo!       checked 3/9/2018 16:30
```