### PR TITLE
Fix issue #30: Change the color of help menu title to White

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function removeTodos(ids){
 }
 function showHelp() {
   console.log(`
-  ${chalk.bgGreen('TODO LIST NODE CLI')}\n
+  ${chalk.white.bgGreen(' TODO LIST NODE CLI ')}\n
   Manage your todos anytime using command line!\n
   Every change will be saved in your system.\n
   usage: 'command [arguments]' - the arguments are space separated!\n


### PR DESCRIPTION
I changed the color of help menu title to white color. I also added spaces in the front and end.

Before :
![file1](https://user-images.githubusercontent.com/20958399/46448107-49d97080-c753-11e8-9405-e0bc12b77cae.png)

After:
![file2](https://user-images.githubusercontent.com/20958399/46448117-5231ab80-c753-11e8-8673-54a9496c367a.png)

Please feel free to give me any feedback. Thanks.